### PR TITLE
Corrected positioning for Popover and Tooltip

### DIFF
--- a/src/util/positioner.js
+++ b/src/util/positioner.js
@@ -132,11 +132,9 @@ export function tryDock(elemRect, alignToRect, windowRect, dock, options = {}) {
 
 export function positionToRect(element, rect, dock = 'bottom', options = {}) {
   const elemRect = element.getBoundingClientRect();
-  const scrollTop = document.body.scrollTop;
-  const scrollLeft = document.body.scrollLeft;
   const windowRect = createRect(
-    -scrollTop,
-    -scrollLeft,
+    0,
+    0,
     document.body.scrollWidth,
     document.body.scrollHeight
   );
@@ -145,10 +143,6 @@ export function positionToRect(element, rect, dock = 'bottom', options = {}) {
   let firstResult = null;
   for (let i = 0; i < docks.length; i++) {
     const result = tryDock(elemRect, rect, windowRect, docks[i], options);
-    result.position.top += scrollTop;
-    result.toPosition.top += scrollTop;
-    result.position.left += scrollLeft;
-    result.toPosition.left += scrollLeft;
     if (result.fits) {
       return result;
     }
@@ -161,8 +155,28 @@ export function positionToRect(element, rect, dock = 'bottom', options = {}) {
 }
 
 export function positionToElement(element, alignToElement, dock = 'bottom', options = {}) {
-  const rect = alignToElement.getBoundingClientRect();
-  return positionToRect(element, rect, dock, options);
+  const elementRect = alignToElement.getBoundingClientRect();
+
+  const body = document.body;
+  const docEl = document.documentElement;
+
+  const scrollTop = window.pageYOffset || docEl.scrollTop || body.scrollTop;
+  const scrollLeft = window.pageXOffset || docEl.scrollLeft || body.scrollLeft;
+
+  const clientTop = docEl.clientTop || body.clientTop || 0;
+  const clientLeft = docEl.clientLeft || body.clientLeft || 0;
+
+  const top = elementRect.top + scrollTop - clientTop;
+  const left = elementRect.left + scrollLeft - clientLeft;
+
+  const itemRect = createRect(
+    top,
+    left,
+    elementRect.width,
+    elementRect.height
+  );
+
+  return positionToRect(element, itemRect, dock, options);
 }
 
 export function positionToCoordinate(element, x, y, dock = 'bottom', options = {}) {

--- a/test/unit/positioner.spec.js
+++ b/test/unit/positioner.spec.js
@@ -8,7 +8,17 @@ describe('Positioner', () => {
         scrollLeft: 0,
         scrollWidth: 500,
         scrollHeight: 500
+      },
+      documentElement: {
+        scrollTop: 0,
+        scrollLeft: 0,
+        scrollWidth: 500,
+        scrollHeight: 500
       }
+    };
+    global.window = {
+      pageYOffset: 0,
+      pageXOffset: 0
     };
   });
 


### PR DESCRIPTION
Fixes #28 

Popover and tooltips are not positioned correctly in Chrome and Firefox when the page is scrolled.

ex: https://qlik-oss.github.io/leonardo-ui/tooltip.html

<img width="1190" alt="screen shot 2017-11-24 at 10 18 14 am" src="https://user-images.githubusercontent.com/1881100/33216203-db3ab812-d100-11e7-861d-acc4499852bc.png">

### Status
```
[ ] Under development
[ x ] Waiting for code review
[ ] Waiting for merge
```
### Information
```
[ ] Contains breaking changes
[ ] Contains new API(s)
[ ] Contains new UI component(s)
[ ] Contains documentation
[ ] Contains test
```
