### PR TITLE
fix: remove pointer-events none for disabled buttons

### DIFF
--- a/src/components/button/_mixins.less
+++ b/src/components/button/_mixins.less
@@ -21,6 +21,10 @@
   &.lui-disabled {
     opacity: 0.6;
     cursor: default;
+    border-color: @border-color;
+  }
+
+  &.lui-disabled {
     pointer-events: none;
   }
 
@@ -62,6 +66,10 @@
   &.lui-disabled {
     opacity: 0.6;
     cursor: default;
+    box-shadow: inset 0 -2px fade(@greyscale-0, 10);
+  }
+
+  &.lui-disabled {
     pointer-events: none;
   }
 
@@ -96,6 +104,9 @@
   &.lui-disabled {
     opacity: 0.6;
     cursor: default;
+  }
+
+  &.lui-disabled {
     pointer-events: none;
   }
 

--- a/src/components/fade-button/_mixins.less
+++ b/src/components/fade-button/_mixins.less
@@ -18,6 +18,9 @@
   &.lui-disabled {
     color: @disabled-text-color;
     cursor: default;
+  }
+
+  &.lui-disabled {
     pointer-events: none;
   }
 }

--- a/src/components/overlay-button/overlay-button.less
+++ b/src/components/overlay-button/overlay-button.less
@@ -64,6 +64,10 @@
     border-color: fade(@greyscale-100, 70);
     background-color: fade(@greyscale-0, 40);
     cursor: default;
+    box-shadow: none;
+  }
+
+  &.lui-disabled {
     pointer-events: none;
   }
 }


### PR DESCRIPTION
This fixes an issue where tooltips did not show on buttons that had the `disabled` attribute set.